### PR TITLE
Force x64 for binaries on Apple M1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node-fetch": "2.6.1",
     "path-match": "1.2.4",
     "promisepipe": "3.0.0",
+    "semver": "7.3.5",
     "stat-mode": "0.3.0",
     "stream-to-promise": "2.2.0",
     "tar": "4.4.18",

--- a/src/install-node.ts
+++ b/src/install-node.ts
@@ -12,7 +12,7 @@ const debug = createDebug('@vercel/fun:install-node');
 
 export function generateNodeTarballUrl(
 	version: string,
-	platform: string = process.platform,
+	platform: NodeJS.Platform = process.platform,
 	arch: string = process.arch
 ): string {
 	if (!version.startsWith('v')) {
@@ -32,7 +32,7 @@ export function generateNodeTarballUrl(
 export async function installNode(
 	dest: string,
 	version: string,
-	platform: string = process.platform,
+	platform: NodeJS.Platform = process.platform,
 	arch: string = process.arch
 ): Promise<void> {
 	// For Apple M1, use the x64 binaries for v14 or less,

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -7,7 +7,7 @@ const debug = createDebug('@vercel/fun:install-python');
 
 export function generatePythonTarballUrl(
 	version: string,
-	platform: string = process.platform,
+	platform: NodeJS.Platform = process.platform,
 	arch: string = process.arch
 ): string {
 	return `https://python-binaries.zeit.sh/python-${version}-${platform}-${arch}.tar.gz`;
@@ -16,9 +16,14 @@ export function generatePythonTarballUrl(
 export async function installPython(
 	dest: string,
 	version: string,
-	platform: string = process.platform,
+	platform: NodeJS.Platform = process.platform,
 	arch: string = process.arch
 ): Promise<void> {
+	// For Apple M1 use the x64 binaries
+	if (platform === 'darwin' && arch === 'arm64') {
+		arch = 'x64';
+	}
+
 	const tarballUrl = generatePythonTarballUrl(version, platform, arch);
 	debug('Downloading Python %s tarball %o', version, tarballUrl);
 	const res = await fetch(tarballUrl);

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,8 +1,8 @@
-import { basename, join } from 'path';
-import { tmpdir } from 'os';
 import execa from 'execa';
+import { tmpdir } from 'os';
 import assert from 'assert';
-import { mkdirp, remove, readdir, readFile, stat } from 'fs-extra';
+import { basename, join } from 'path';
+import { mkdirp, remove, readFile, stat } from 'fs-extra';
 import {
 	funCacheDir,
 	initializeRuntime,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,6 +2254,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -3181,6 +3188,13 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
+semver@7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -3912,6 +3926,11 @@ yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
For Node.js, official binaries are not provided for versions <= 14.

For Python, the binaries compiled manually are also only for x64, so force it in that case as well.