### PR TITLE
fix: Ref custom error classes instead of new.target

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,7 +12,7 @@ interface LambdaErrorPayload {
 export class LambdaError extends Error {
 	constructor(data: LambdaErrorPayload = {}) {
 		super(data.errorMessage || 'Unspecified runtime initialization error');
-		Object.setPrototypeOf(this, new.target.prototype);
+		Object.setPrototypeOf(this, LambdaError.prototype);
 
 		Object.defineProperty(this, 'name', {
 			value: data.errorType || this.constructor.name

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,8 @@ export class ValidationError extends Error {
 		super(message);
 
 		// Restore prototype chain (see https://stackoverflow.com/a/41102306/376773)
-		this.name = new.target.name;
-		const actualProto = new.target.prototype;
+		this.name = ValidationError.name;
+		const actualProto = ValidationError.prototype;
 		Object.setPrototypeOf(this, actualProto);
 	}
 }


### PR DESCRIPTION
While there's nothing wrong with using `new.target`, it turns out that `ncc` has been stripping them for some reason. Subsequently, if an error occurred while invoking a lambda function, the actual error would never be displayed since the `LambdaError` creation would fail with an error `Object.setPrototypeOf()` with an object or `null`.

For example, the original code looked like this:
```
Object.setPrototypeOf(this, new.target.prototype);
```

But `ncc` would output:
```
Object.setPrototypeOf(this, /* unsupported import.meta.prototype */ undefined);
```

I couldn't find any instances where we derive errors from `LambdaError` or `ValidationError`, so it shouldn't be a problem to replace `new.target` with the class name.

This should partially fix https://github.com/vercel/vercel/issues/8000.