### PR TITLE
fix(ci): handle node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   build:
-    name: Test Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: Test Node.js ${{ matrix.node }} on ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [16, 18]
+        node: [16, 18]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,10 +27,10 @@ jobs:
       with:
         go-version: '1.13.15'
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
 
     - name: Print Node.js Version
       run: node --version


### PR DESCRIPTION
This was using `matrix.node` in some places but `matrix.node_version` in others