### PR TITLE
No longer rely on system Python for installs of python3 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ implemented are:
  * `nodejs14.x` for Node.js Lambda functions using a downloaded Node v14.18.1 binary
  * `python` for Python Lambda functions using the system `python` binary
  * `python2.7` for Python Lambda functions using a downloaded Python v2.7.12 binary
- * `python3` for Python Lambda functions using the system `python3` binary (or fallback to `python`)
+ * `python3` for Python Lambda functions using the system `python3` binary
  * `python3.6` for Python Lambda functions using a downloaded Python v3.6.8 binary
  * `python3.7` for Python Lambda functions using a downloaded Python v3.7.2 binary
  * `go1.x` for Lambda functions written in Go - binary must be compiled for your platform

--- a/src/runtimes/python3/index.ts
+++ b/src/runtimes/python3/index.ts
@@ -1,6 +1,10 @@
 import { Runtime } from '../../types';
+import { installPython } from '../../install-python';
 import { runtimes, initializeRuntime } from '../../runtimes';
 
-export async function init(_runtime: Runtime): Promise<void> {
-	await initializeRuntime(runtimes.python);
+export async function init({ cacheDir }: Runtime): Promise<void> {
+	await Promise.all([
+		initializeRuntime(runtimes.python),
+		installPython(cacheDir, '3.6.8')
+	]);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -719,7 +719,7 @@ it(
 			}),
 		async fn => {
 			const payload = await fn();
-			assert.equal(payload['platform.python_version'][0], '3');
+			assert.equal(payload['platform.python_version'], '3.6.8');
 		}
 	)
 );


### PR DESCRIPTION
Back in #34 we added Python 3 that would fallback to system Python 3 if it exists. In MacOS 12.3 Apple [removed system python](https://discussions.apple.com/thread/254787935#:~:text=Apple%20removed%20the%20Python%202.7,and%20unsupported%20by%20Python.org).

This PR updates `python3` to behave like the other python runtimes by calling `installPython`.

See:
* https://github.com/orgs/vercel/discussions/2524
* https://vercel.sentry.io/issues/1148731861/?query=is%3Aunresolved+python3