### PR TITLE
fix: Update README and no longer rely on system python

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,7 @@ implemented are:
 
 [cgroup freezer]: https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
 [custom runtimes]: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html
+
+## Releasing
+
+See [`semantic-release`](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
Updates README to describe releases and also released current `main` with #93 on it which was merged before I knew how to trigger a release.