### PR TITLE
Remove uuid package and replace with crypto.randomUUID()

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "tar": "4.4.18",
     "tree-kill": "1.2.2",
     "uid-promise": "1.0.0",
-    "uuid": "3.3.2",
     "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"
   },
@@ -51,7 +50,6 @@
     "@types/node": "10.12.29",
     "@types/node-fetch": "2.5.0",
     "@types/tar": "4.0.0",
-    "@types/uuid": "8.3.1",
     "@types/yauzl-promise": "2.1.0",
     "codecov": "3.7.1",
     "cpy-cli": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ dependencies:
   uid-promise:
     specifier: 1.0.0
     version: 1.0.0
-  uuid:
-    specifier: 3.3.2
-    version: 3.3.2
   xdg-app-paths:
     specifier: 5.1.0
     version: 5.1.0
@@ -91,9 +88,6 @@ devDependencies:
   '@types/tar':
     specifier: 4.0.0
     version: 4.0.0
-  '@types/uuid':
-    specifier: 8.3.1
-    version: 8.3.1
   '@types/yauzl-promise':
     specifier: 2.1.0
     version: 2.1.0
@@ -937,10 +931,6 @@ packages:
     resolution: {integrity: sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==}
     dependencies:
       '@types/node': 10.12.29
-    dev: true
-
-  /@types/uuid@8.3.1:
-    resolution: {integrity: sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==}
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -5698,6 +5688,7 @@ packages:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
+    dev: true
 
   /v8-to-istanbul@8.1.1:
     resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -1,5 +1,4 @@
 import ms from 'ms';
-import uuid from 'uuid/v4';
 import createDebug from 'debug';
 import { promisify } from 'util';
 import { AddressInfo } from 'net';
@@ -77,10 +76,9 @@ export default class NativeProvider implements Provider {
 		const memorySize =
 			typeof params.MemorySize === 'number' ? params.MemorySize : 128;
 		const logGroupName = `aws/lambda/${functionName}`;
-		const logStreamName = `2019/01/12/[${version}]${uuid().replace(
-			/\-/g,
-			''
-		)}`;
+		const logStreamName = `2019/01/12/[${version}]${crypto
+			.randomUUID()
+			.replace(/\-/g, '')}`;
 
 		// https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
 		const env = {

--- a/src/runtime-server.ts
+++ b/src/runtime-server.ts
@@ -3,7 +3,6 @@ import { parse } from 'url';
 import { Server } from 'http';
 import createDebug from 'debug';
 import { run, text } from 'micro';
-import { v4 as uuid } from 'uuid';
 import createPathMatch from 'path-match';
 import once from '@tootallnate/once';
 
@@ -44,7 +43,7 @@ export class RuntimeServer extends Server {
 		this.nextDeferred = createDeferred<void>();
 		this.invokeDeferred = null;
 		this.resultDeferred = null;
-		this.currentRequestId = uuid();
+		this.currentRequestId = crypto.randomUUID();
 	}
 
 	async serve(


### PR DESCRIPTION
In my NextJS projects I get the following warning from npm:

`npm WARN deprecated uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.`

I tracked it down to this package, and I found the instances where uuid() was used and replaced it with crypto.randomUUID(), then I removed the package and its types. Crypto's function is actually supposed to be much faster than using the uuid package.