### PR TITLE
fix: usage of `uuid` that uses `Math.random()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tar": "4.4.18",
     "tree-kill": "1.2.2",
     "uid-promise": "1.0.0",
-    "uuid": "3.3.2",
+    "uuid": "9.0.1",
     "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ dependencies:
     specifier: 1.0.0
     version: 1.0.0
   uuid:
-    specifier: 3.3.2
-    version: 3.3.2
+    specifier: 9.0.1
+    version: 9.0.1
   xdg-app-paths:
     specifier: 5.1.0
     version: 5.1.0
@@ -5698,6 +5698,12 @@ packages:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
+    dev: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /v8-to-istanbul@8.1.1:
     resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -1,5 +1,5 @@
 import ms from 'ms';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import createDebug from 'debug';
 import { promisify } from 'util';
 import { AddressInfo } from 'net';


### PR DESCRIPTION
fixes https://github.com/vercel/vercel/issues/11263.