### PR TITLE
fix: update node versions in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [16, 18]
+        node: [18, 20, 22]
 
     runs-on: ${{ matrix.os }}
 
@@ -50,7 +50,7 @@ jobs:
         CI: true
 
     - name: Maybe Release
-      if: matrix.os == 'ubuntu-latest' && matrix.node == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: matrix.os == 'ubuntu-latest' && matrix.node == 22 && github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
Node 16 support is being discontinued by Vercel. Remove that from the test's Node version matrix.

Add Node 20 and 22, while we're at it.