### PR TITLE
Fix/update UUID to 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tinyexec": "0.3.2",
     "tree-kill": "1.2.2",
     "uid-promise": "1.0.0",
-    "uuid": "3.3.2",
+    "uuid": "11.1.0",
     "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       uuid:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: 11.1.0
+        version: 11.1.0
       xdg-app-paths:
         specifier: 5.1.0
         version: 5.1.0
@@ -183,7 +183,6 @@ packages:
   '@esbuild/darwin-arm64@0.24.2':
     resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
     engines: {node: '>=18'}
-    cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.24.2':
@@ -2224,6 +2223,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@3.3.2:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
@@ -4492,6 +4495,8 @@ snapshots:
   use@3.1.1: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
 
   uuid@3.3.2: {}
 

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -1,5 +1,5 @@
 import ms from 'ms';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import createDebug from 'debug';
 import { promisify } from 'node:util';
 import { AddressInfo } from 'node:net';


### PR DESCRIPTION
- uuid: `3.3.2` -> `11.1.0`
- fix uuid import to be consistent with other usage & work with new version