### PR TITLE
Update README CI badge to match current workflow (fixes #126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ƒun
-[![Build Status](https://github.com/vercel/fun/workflows/Node%20CI/badge.svg)](https://github.com/vercel/fun/actions?workflow=Node+CI)
+[![CI](https://github.com/vercel/fun/actions/workflows/test.yml/badge.svg)](https://github.com/vercel/fun/actions/workflows/test.yml)
+
 
 Local serverless function λ development runtime.
 


### PR DESCRIPTION
This PR fixes the broken CI status badge in the README by updating it to reference the current GitHub Actions workflow file. It resolves the issue caused by an outdated workflow name and restores the correct build status display.

<img width="859" height="170" alt="Screenshot from 2026-01-29 22-38-54" src="https://github.com/user-attachments/assets/f821d8c6-6f8a-49bd-903a-a584d2df0309" />
